### PR TITLE
ci(github-actions): conditional artifact upload & cleanup

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,23 +13,62 @@ on:
       - reopened
       - synchronize
   # allow manual run
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      publish_artifacts:
+        type: boolean
+        description: Gather artifacts
+        required: true
+        default: false
+  repository_dispatch:
+    types: [deploy-command]
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
-  install-and-test:
+  configure:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      ref: ${{ steps.configure.outputs.ref }}
+      publish_artifacts: ${{ steps.configure.outputs.publish_artifacts }}
     steps:
-    - uses: actions/checkout@v3
+    - name: Get version
+      id: version
+      run: echo "version=${GITHUB_REF/refs\/tags\//}"
+      if: |
+        github.event_name == 'push' &&
+        github.event.repository.full_name == github.repository &&
+        startsWith(github.ref, 'refs/tags/v')
+    - name: Gather workflow info
+      id: configure
+      run: |
+        # The ref of the commit to checkout (do not use the merge commit if pull request)
+        if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          echo "ref=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+        elif [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then
+          echo "ref=${{ github.event.client_payload.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+        elif [[ "${{ steps.version.outputs.version }}" != "" ]]; then
+          echo "ref=${{ steps.version.outputs.version }}" >> $GITHUB_OUTPUT
+        else
+          echo "ref=${{ github.sha }}" >> $GITHUB_OUTPUT
+        fi
+
+        if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          echo "publish_artifacts=${{ github.event.inputs.publish_artifacts }}" >> $GITHUB_OUTPUT
+        elif [[ "${{ steps.version.outputs.version }}" != "" ]]; then
+          echo "publish_artifacts=true" >> $GITHUB_OUTPUT
+        fi
+    - name: Checkout
+      uses: actions/checkout@v3
     - name: Setup .npmrc
       run: printf '@polito:registry=https://npm.pkg.github.com\n//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}\n' > .npmrc
     - name: Install npm dependencies
       run: npm install
 
   build-android:
-    needs: install-and-test
+    needs: configure
     runs-on: ubuntu-latest
     steps: 
     - uses: actions/checkout@v3
@@ -38,27 +77,30 @@ jobs:
     - name: Install npm dependencies
       run: npm install
     - name: Build Android Release
-      run: cd android && ./gradlew assembleRelease && ./gradlew bundleRelease
-    - name: Upload Artifact
+      working-directory: ./android
+      run: ./gradlew assembleRelease
+    - name: Bundle Android Release
+      working-directory: ./android
+      run: ./gradlew bundleRelease
+    - name: Upload Artifacts
+      if: needs.configure.outputs.publish_artifacts
       uses: actions/upload-artifact@v3
       with:
         name: android-release
-        path: |
-          android/app/build/outputs/apk/release/
-          android/app/build/outputs/bundle/release/
+        path: android/app/build/outputs/
+
   build-ios:
     env:
       MATCH_PASSWORD: ${{ secrets.FASTLANE_MATCH_KEY }}
       FASTLANE_PASSWORD: ${{ secrets.FASTLANE_POLI_MOBILE_PW }}
       FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: ${{ secrets.FASTLANE_APPLE_DEV_PW }}
       LANG: ${{ 'en_US.UTF-8' }}
-      #ImageOS: macos12
-      ImageOS: macos1015
+      ImageOS: macos12
       CI: "true"
       MATCH_GIT_PRIVATE_KEY: "./github_access.pk"
       GYM_SILENT: "true"
 
-    needs: install-and-test
+    needs: configure
     runs-on: [self-hosted, macos-12]
     steps:
     - name: Select Xcode
@@ -101,8 +143,8 @@ jobs:
         chmod 600 ${MATCH_GIT_PRIVATE_KEY}
         bundle exec fastlane beta
     - name: Upload Artifacts
+      if: needs.configure.outputs.publish_artifacts
       uses: actions/upload-artifact@v3
       with:
         name: ios-release
-        path: |
-          ios/build/students.ipa
+        path: ios/build/students.ipa


### PR DESCRIPTION
This PR changes GitHub Actions behavior so that artifacts upload is done only upon
- manual action triggering,
- upon push of version-tag.

Further cleanup of build action is included.