### PR TITLE
fix(ui): transcript progress charts wrong values

### DIFF
--- a/src/features/teaching/screens/TeachingScreen.tsx
+++ b/src/features/teaching/screens/TeachingScreen.tsx
@@ -186,9 +186,9 @@ export const TeachingScreen = ({ navigation }: Props) => {
                     data={
                       studentQuery.data && studentQuery.data.totalCredits
                         ? [
-                            studentQuery.data?.totalAttendedCredits /
+                            (studentQuery.data?.totalAttendedCredits ?? 0) /
                               studentQuery.data?.totalCredits,
-                            studentQuery.data?.totalAcquiredCredits /
+                            (studentQuery.data?.totalAcquiredCredits ?? 0) /
                               studentQuery.data?.totalCredits,
                           ]
                         : []

--- a/src/features/teaching/screens/TranscriptScreen.tsx
+++ b/src/features/teaching/screens/TranscriptScreen.tsx
@@ -88,8 +88,8 @@ export const TranscriptScreen = () => {
             data={
               totalCredits
                 ? [
-                    totalAttendedCredits ?? 0 / totalCredits,
-                    totalAcquiredCredits ?? 0 / totalCredits,
+                    (totalAttendedCredits ?? 0) / totalCredits,
+                    (totalAcquiredCredits ?? 0) / totalCredits,
                   ]
                 : []
             }
@@ -129,8 +129,8 @@ export const TranscriptScreen = () => {
             data={
               enrollmentCredits
                 ? [
-                    enrollmentAttendedCredits ?? 0 / enrollmentCredits,
-                    enrollmentAcquiredCredits ?? 0 / enrollmentCredits,
+                    (enrollmentAttendedCredits ?? 0) / enrollmentCredits,
+                    (enrollmentAcquiredCredits ?? 0) / enrollmentCredits,
                   ]
                 : []
             }


### PR DESCRIPTION
A wrong nullish coalescing operator precedence caused the values to be out of scale