### PR TITLE
fix(ui): hide tabs when useHideTabs hook is rendered

### DIFF
--- a/src/core/components/RootNavigator.tsx
+++ b/src/core/components/RootNavigator.tsx
@@ -57,7 +57,7 @@ export const RootNavigator = () => {
 
   const { data: messages } = useGetModalMessages();
 
-  const { onboardingStep } = usePreferencesContext();
+  const { onboardingStep, updatePreference } = usePreferencesContext();
 
   useEffect(() => {
     if (onboardingStep && onboardingStep >= 3) return;

--- a/src/core/hooks/useHideTabs.ts
+++ b/src/core/hooks/useHideTabs.ts
@@ -1,6 +1,9 @@
 import { useCallback } from 'react';
+import { Platform } from 'react-native';
 
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
+
+import { tabBarStyle } from '../../utils/tab-bar';
 
 export const useHideTabs = (
   onFocusIn?: () => void,
@@ -9,14 +12,16 @@ export const useHideTabs = (
   const navigation = useNavigation();
   useFocusEffect(
     useCallback(() => {
+      // Ios tab bar is hidden by default in modal context
+      if (Platform.OS === 'ios') return;
       const parent = navigation.getParent()!;
       parent.setOptions({
-        tabBarVisible: false,
+        tabBarStyle: { display: 'none' },
       });
       onFocusIn && onFocusIn();
       return () => {
         parent.setOptions({
-          tabBarVisible: true,
+          tabBarStyle,
         });
         onFocusOut && onFocusOut();
       };


### PR DESCRIPTION
This fixes buggy tabs interface on Android devices for both the onboarding modal and the messages modal

Closes #378