### PR TITLE
fix(requestScreen): onSubmit if condition

### DIFF
--- a/src/features/teaching/screens/ExamRequestScreen.tsx
+++ b/src/features/teaching/screens/ExamRequestScreen.tsx
@@ -36,7 +36,7 @@ export const ExamRequestScreen = ({ route, navigation }: Props) => {
   });
 
   const onSubmit = async () => {
-    if (state.value?.length ?? 0 === 0) {
+    if ((state.value?.length ?? 0) === 0) {
       setState({ ...state, isError: true });
       return;
     }


### PR DESCRIPTION
The issue seems to be with the condition in the if statement. The nullish coalescing operator `(??)` has lower precedence than the equality operator `(===)`, so the condition is not being evaluated

To fix this, you should add parentheses around `(state.value?.length ?? 0)` to ensure that the nullish coalescing operation happens before the equality check:

`
if ((state.value?.length ?? 0) === 0) { ... }`

This will correctly return true if state.value is null, undefined, or an empty string, and false otherwise.

 resolves #406
