### PR TITLE
fix(filenames)!: files get saved with their proper names

### DIFF
--- a/src/features/courses/components/CourseFileListItem.tsx
+++ b/src/features/courses/components/CourseFileListItem.tsx
@@ -118,9 +118,11 @@ export const CourseFileListItem = ({
     if (!ext) {
       ext = item.name?.match(/\.(.+)$/)?.[1] ?? null;
     }
-    return [courseFilesCache, [item.id, ext].filter(notNullish).join('.')].join(
-      '/',
-    );
+    // item.name already contains the extension
+    return [
+      courseFilesCache,
+      item.name ?? [item.id, ext].filter(notNullish).join('.'),
+    ].join('/');
   }, [courseFilesCache, item]);
   const {
     isDownloaded,


### PR DESCRIPTION
Closes #139 

Saves the course files with their proper names, if the name doesn't exist, defaults back to the `id`.

## WARNING

This update causes all of the old downloaded files disappear on the user's device _(I think)_. Maybe there should be a way to access those or even completely delete them from user's device.


https://github.com/polito/students-app/assets/40398628/d8a2c71e-fdef-48df-a4dc-d6f4377d1260