### PR TITLE
fix(login): enable login even when fcm is not enabled, but display warning

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -490,7 +490,8 @@
     "title": "Log in with your polito.it credentials",
     "unsupportedUserType": "User type not supported: only students can log in to PoliTO Students.",
     "usernameLabel": "Student ID",
-    "usernameLabelAccessibility": "Enter your username here"
+    "usernameLabelAccessibility": "Enter your username here",
+    "fcmUnsupported": "An error occurred during push notifications setup. This problem can be caused by the lack of Google Play Services on this device. It is possible to keep using this app, however push notifications won't be received."
   },
   "messageScreen": {
     "backTitle": "Archive",

--- a/assets/translations/it.json
+++ b/assets/translations/it.json
@@ -490,7 +490,8 @@
     "title": "Accedi con le tue credenziali polito.it",
     "unsupportedUserType": "Tipo utente non supportato: PoliTO Students è accessibile solamente agli studenti.",
     "usernameLabel": "Matricola",
-    "usernameLabelAccessibility": "Inserisci qui il tuo username"
+    "usernameLabelAccessibility": "Inserisci qui il tuo username",
+    "fcmUnsupported": "Si è verificato un errore durante l'attivazione delle notifiche push. Questo problema può essere causato dall'assenza dei servizi Google su questo dispositivo. È possibile continuare ad utilizzare l'app ma non si riceveranno notifiche push."
   },
   "messageScreen": {
     "backTitle": "Archivio",


### PR DESCRIPTION
This PR adds a check around the fcm token retrieval that possibly outputs a warning if retrieval fails (and we're not in dev mode).

Fixes #513 