### PR TITLE
ci: upgrade actions/upload-artifact to v4 in gh build action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -211,7 +211,7 @@ jobs:
       if: |
         github.event_name == 'push' &&
         github.ref_type == 'tag'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: android-release
         path: android/app/build/outputs/apk/release/*.apk


### PR DESCRIPTION
Upgrade github actions upload-artifact action on the main builder