### PR TITLE
fix(ci): enable android backup branch in case of broken sentry

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -215,6 +215,7 @@ jobs:
       env:
         STORE_TRACK: ${{ needs.configure.outputs.push_to_playstore }}
       run: bundle exec fastlane release
+      continue-on-error: true
     - name: Fastlane RELEASE lane [without Sentry]
       if: steps.fastlane_release_android.outcome == 'failure'
       working-directory: ./android


### PR DESCRIPTION
This PR adds a missing flag on the builder in order to avoid sentry to block releases creation