### PR TITLE
fix(statistics): add missing prefix in query cache key

### DIFF
--- a/src/core/queries/offeringHooks.ts
+++ b/src/core/queries/offeringHooks.ts
@@ -16,6 +16,7 @@ import { compact } from 'lodash';
 export const OFFERING_QUERY_KEY = ['offering'];
 export const DEGREES_QUERY_PREFIX = 'degrees';
 export const COURSES_QUERY_PREFIX = 'courses';
+export const STATISTICS_QUERY_PREFIX = 'statistics';
 const useOfferingClient = (): OfferingApi => {
   return new OfferingApi();
 };
@@ -104,6 +105,7 @@ export const useGetCourseStatistics = ({
     queryKey: compact([
       DEGREES_QUERY_PREFIX,
       COURSES_QUERY_PREFIX,
+      STATISTICS_QUERY_PREFIX,
       courseShortcode,
       year,
       teacherId,

--- a/src/features/offering/screens/DegreeCourseScreen.tsx
+++ b/src/features/offering/screens/DegreeCourseScreen.tsx
@@ -65,8 +65,8 @@ export const DegreeCourseScreen = ({ route }: Props) => {
 
   const moreStaffCount = useMemo(() => {
     if (!offeringCourse) return undefined;
-    return offeringCourse.staff?.length > 3
-      ? offeringCourse.staff?.length - 3
+    return offeringCourse.staff.length > 3
+      ? offeringCourse.staff.length - 3
       : undefined;
   }, [offeringCourse]);
 
@@ -163,16 +163,16 @@ export const DegreeCourseScreen = ({ route }: Props) => {
             </Row>
           </Card>
           {offeringCourse?.hours &&
-            (offeringCourse.hours?.lecture ||
-              offeringCourse.hours?.classroomExercise ||
-              offeringCourse.hours?.labExercise ||
-              offeringCourse.hours?.tutoring) && (
+            (offeringCourse.hours.lecture ||
+              offeringCourse.hours.classroomExercise ||
+              offeringCourse.hours.labExercise ||
+              offeringCourse.hours.tutoring) && (
               <OverviewList>
-                {!!offeringCourse?.hours?.lecture && (
+                {!!offeringCourse.hours.lecture && (
                   <ListItem
                     inverted
                     title={t('degreeCourseScreen.hours', {
-                      hours: offeringCourse?.hours?.lecture?.toString(),
+                      hours: offeringCourse.hours.lecture.toString(),
                     })}
                     titleStyle={styles.title}
                     titleProps={listTitleProps}
@@ -184,8 +184,7 @@ export const DegreeCourseScreen = ({ route }: Props) => {
                   <ListItem
                     inverted
                     title={t('degreeCourseScreen.hours', {
-                      hours:
-                        offeringCourse?.hours?.classroomExercise?.toString(),
+                      hours: offeringCourse.hours.classroomExercise.toString(),
                     })}
                     titleStyle={styles.title}
                     titleProps={listTitleProps}
@@ -209,7 +208,7 @@ export const DegreeCourseScreen = ({ route }: Props) => {
                   <ListItem
                     inverted
                     title={t('degreeCourseScreen.hours', {
-                      hours: offeringCourse?.hours?.tutoring?.toString(),
+                      hours: offeringCourse.hours.tutoring.toString(),
                     })}
                     titleStyle={styles.title}
                     titleProps={listTitleProps}
@@ -242,20 +241,20 @@ export const DegreeCourseScreen = ({ route }: Props) => {
               title={t('degreeCourseScreen.staff')}
               linkToMoreCount={moreStaffCount}
               linkTo={
-                moreStaffCount
+                moreStaffCount && offeringCourse
                   ? {
                       screen: 'Staff',
                       params: {
-                        courseShortcode: offeringCourse?.shortcode,
+                        courseShortcode: offeringCourse.shortcode,
                         year: initialYear,
-                        staff: offeringCourse!.staff,
+                        staff: offeringCourse.staff,
                       },
                     }
                   : undefined
               }
             />
             <OverviewList emptyStateText={t('degreeCourseScreen.noStaff')}>
-              {offeringCourse?.staff.slice(0, 3).map(item => (
+              {offeringCourse?.staff?.slice(0, 3).map(item => (
                 <StaffListItem
                   key={`${item.id}${item.courseId}`}
                   staff={item}


### PR DESCRIPTION
This pull request introduces a new query key for course statistics and refines how course and staff data are accessed in the `DegreeCourseScreen` to improve code clarity and reliability. The main focus is on enhancing the consistency of property access by removing unnecessary optional chaining where the data is guaranteed to exist, and on supporting statistics queries.

**Query Key and Data Fetching Improvements:**

* Added `STATISTICS_QUERY_PREFIX` constant and included it in the `useGetCourseStatistics` query key for more precise cache management and data fetching related to course statistics.

The missing prefix was causing interference because of collisions with another query, **resulting in broken data types under the hood** that could not be intercepted by typescript and resulted in app crash.