### PR TITLE
fix: ios26 rn-screens

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2614,7 +2614,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (4.18.0):
+  - RNScreens (4.13.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2638,9 +2638,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 4.18.0)
+    - RNScreens/common (= 4.13.1)
     - Yoga
-  - RNScreens/common (4.18.0):
+  - RNScreens/common (4.13.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -3258,7 +3258,7 @@ SPEC CHECKSUMS:
   rnmapbox-maps: f7eeb3af74b6bf5ba93955ebfc89e296e1798fdb
   RNPermissions: 80777ea1b89df81be475044e2d7effad5fc788ea
   RNReanimated: 1a94be2654cbbe861fba2a872c84a142351e9ec0
-  RNScreens: f38464ec1e83bda5820c3b05ccf4908e3841c5cc
+  RNScreens: 7e56b051227a1a11c3068849d1a9a5dd457537df
   RNSentry: 0f61ae3c111d9129a978aeedd1fa05d0cd2307a9
   RNSVG: 8a1054afe490b5d63b9792d7ae3c1fde8c05cdd0
   SDWebImage: 16309af6d214ba3f77a7c6f6fdda888cb313a50a

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
         "react-native-reanimated": "^3.19.2",
         "react-native-render-html": "^6.3.4",
         "react-native-safe-area-context": "^5.6.1",
-        "react-native-screens": "^4.16.0",
+        "react-native-screens": "4.13.1",
         "react-native-svg": "^15.12.0",
         "react-native-uuid": "^2.0.3",
         "react-native-video": "^6.16.1",
@@ -16764,15 +16764,26 @@
       }
     },
     "node_modules/react-native-screens": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.18.0.tgz",
-      "integrity": "sha512-mRTLWL7Uc1p/RFNveEIIrhP22oxHduC2ZnLr/2iHwBeYpGXR0rJZ7Bgc0ktxQSHRjWTPT70qc/7yd4r9960PBQ==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.13.1.tgz",
+      "integrity": "sha512-EESsMAtyzYcL3gpAI2NKKiIo+Ew0fnX4P4b3Zy/+MTc6SJIo3foJbZwdIWd/SUBswOf7IYCvWBppg+D8tbwnsw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
+        "react-native-is-edge-to-edge": "^1.2.1",
         "warn-once": "^0.1.0"
       },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-screens/node_modules/react-native-is-edge-to-edge": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.2.1.tgz",
+      "integrity": "sha512-FLbPWl/MyYQWz+KwqOZsSyj2JmLKglHatd3xLZWskXOpRaio4LfEDEz8E/A6uD8QoTHW6Aobw1jbEwK7KMgR7Q==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "*",
         "react-native": "*"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "react-native-reanimated": "^3.19.2",
     "react-native-render-html": "^6.3.4",
     "react-native-safe-area-context": "^5.6.1",
-    "react-native-screens": "^4.16.0",
+    "react-native-screens": "4.13.1",
     "react-native-svg": "^15.12.0",
     "react-native-uuid": "^2.0.3",
     "react-native-video": "^6.16.1",


### PR DESCRIPTION
This pull request makes a minor update to the `package.json` dependencies. The version of `react-native-screens` has been downgraded from `^4.16.0` to `4.13.1`.

WHICH WAS BREAKING OUR LOVELY IOS 26+