### PR TITLE
fix: fixed wrong visualization of grade in RecordedGradeScreen

### DIFF
--- a/src/features/transcript/screens/RecordedGradeScreen.tsx
+++ b/src/features/transcript/screens/RecordedGradeScreen.tsx
@@ -87,7 +87,7 @@ export const RecordedGradeScreen = ({ navigation, route }: Props) => {
                 <View>
                   <Text>{`${formatDate(new Date(grade.date))} ${
                     accessibility?.fontSize && accessibility.fontSize < 150
-                      ? '-' +
+                      ? '- ' +
                         t('common.creditsWithUnit', {
                           credits: grade.credits,
                         })


### PR DESCRIPTION
Fixed wrong visualization of string including grade in RecordedGradeScreen

Example: 
![proof_pull_request](https://github.com/user-attachments/assets/e56da314-486c-4f39-b217-5262414d10a8)
