### PR TITLE
fix(notifications): possible resolve infinite ticket recursion

### DIFF
--- a/src/core/hooks/useDownloadCourseFile.ts
+++ b/src/core/hooks/useDownloadCourseFile.ts
@@ -188,7 +188,13 @@ export const useDownloadCourseFile = (
         throw new UnsupportedFileTypeError(`Cannot open file ${fromUrl}`);
       }
     });
-    clearNotificationScope(['teaching', 'courses', courseId, 'files', fileId]);
+    clearNotificationScope([
+      'teaching',
+      'courses',
+      `${courseId}`,
+      'files',
+      fileId,
+    ]);
   }, [fromUrl, toFile, clearNotificationScope, courseId, fileId]);
 
   return {

--- a/src/core/types/notifications.ts
+++ b/src/core/types/notifications.ts
@@ -37,10 +37,10 @@ export interface UnreadNotificationsByScope {
     courses?: {
       [courseId: string]: {
         files?: {
-          [fileId: number]: Notification[];
+          [fileId: string]: Notification[];
         };
         notices?: {
-          [noticeId: number]: Notification[];
+          [noticeId: string]: Notification[];
         };
         lectures?: Notification[];
       };

--- a/src/features/courses/components/CourseFileListItem.tsx
+++ b/src/features/courses/components/CourseFileListItem.tsx
@@ -112,7 +112,7 @@ export const CourseFileListItem = memo(
     const { setFeedback } = useFeedbackContext();
     const { getUnreadsCount } = useNotifications();
     const fileNotificationScope = useMemo(
-      () => ['teaching', 'courses', courseId.toString(), 'files', item.id],
+      () => ['teaching', 'courses', `${courseId}`, 'files', item.id] as const,
       [courseId, item.id],
     );
     const [isCorrupted, setIsCorrupted] = useState(false);

--- a/src/features/courses/screens/CourseFilesScreen.tsx
+++ b/src/features/courses/screens/CourseFilesScreen.tsx
@@ -34,7 +34,7 @@ export const CourseFilesScreen = ({ navigation, route }: Props) => {
   const { updatePreference } = usePreferencesContext();
 
   useOnLeaveScreen(() => {
-    clearNotificationScope(['teaching', 'courses', courseId, 'files']);
+    clearNotificationScope(['teaching', 'courses', `${courseId}`, 'files']);
   });
 
   useFocusEffect(

--- a/src/features/courses/screens/CourseInfoScreen.tsx
+++ b/src/features/courses/screens/CourseInfoScreen.tsx
@@ -85,7 +85,11 @@ export const CourseInfoScreen = () => {
     courseQuery.data?.staff.map(s => s.id),
   );
 
-  const unreadsCurrentYear = getUnreadsCount(['teaching', 'courses', courseId]);
+  const unreadsCurrentYear = getUnreadsCount([
+    'teaching',
+    'courses',
+    `${courseId}`,
+  ]);
   const unreadsPrevEditions =
     (getUnreadsCountPerCourse(null, editions) ?? 0) - (unreadsCurrentYear ?? 0);
 
@@ -118,7 +122,7 @@ export const CourseInfoScreen = () => {
   const menuActions = useMemo(() => {
     if (!editions) return [];
     return editions.map(e => {
-      const editionsCount = getUnreadsCount(['teaching', 'courses', e.id]);
+      const editionsCount = getUnreadsCount(['teaching', 'courses', `${e.id}`]);
       return {
         id: `${e.id}`,
         title: e.year.toString(),

--- a/src/features/courses/screens/CourseNoticesScreen.tsx
+++ b/src/features/courses/screens/CourseNoticesScreen.tsx
@@ -43,7 +43,7 @@ export const CourseNoticesScreen = () => {
     [noticesQuery],
   );
   const noticesNotificationScope = useMemo(
-    () => ['teaching', 'courses', courseId.toString(), 'notices'],
+    () => ['teaching', 'courses', `${courseId}`, 'notices'] as const,
     [courseId],
   );
 
@@ -77,7 +77,9 @@ export const CourseNoticesScreen = () => {
               date: formatDate(notice.publishedAt),
             },
           }}
-          unread={!!getUnreadsCount([...noticesNotificationScope, notice.id])}
+          unread={
+            !!getUnreadsCount([...noticesNotificationScope, `${notice.id}`])
+          }
         />
       )}
       ListFooterComponent={<BottomBarSpacer />}

--- a/src/features/courses/screens/NoticeScreen.tsx
+++ b/src/features/courses/screens/NoticeScreen.tsx
@@ -37,9 +37,9 @@ export const NoticeScreen = ({ route }: Props) => {
       clearNotificationScope([
         'teaching',
         'courses',
-        courseId.toString(),
+        `${courseId}`,
         'notices',
-        noticeId,
+        `${noticeId}`,
       ]);
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []),

--- a/src/features/tickets/screens/TicketScreen.tsx
+++ b/src/features/tickets/screens/TicketScreen.tsx
@@ -127,20 +127,20 @@ export const TicketScreen = ({ route, navigation }: Props) => {
 
   useScreenTitle(ticket?.subject);
 
-  useEffect(() => {
+  const markAsReadIfNeeded = useCallback(async () => {
     if (!ticket) {
       return;
     }
-    clearNotificationScope([
-      'services',
-      'tickets',
-      ticket.id.toString(),
-    ] as unknown as Parameters<typeof clearNotificationScope>['0']); // TODO check PathExtractor type
-    if (ticket.unreadCount === 0) {
+    await clearNotificationScope(['services', 'tickets', ticket.id.toString()]);
+    if (!ticket.unreadCount) {
       return;
     }
     markAsRead();
   }, [markAsRead, clearNotificationScope, ticket]);
+
+  useEffect(() => {
+    markAsReadIfNeeded();
+  }, [markAsReadIfNeeded]);
 
   const headerRight = useCallback(
     () =>


### PR DESCRIPTION
This pull request refactors how notification scopes are handled throughout the codebase by standardizing the use of string-based IDs for course, file, and notice identifiers. It also introduces a new `PathExtractor` type to improve type safety and consistency when working with notification paths. These changes ensure that notification management functions work reliably and are less prone to type errors.

**Type safety and notification scope improvements:**

* Added the `PathExtractor` type to enforce correct typing for notification paths in functions like `clearNotificationScope` and `getUnreadsCount`, improving type safety when accessing nested notification data. [[1]](diffhunk://#diff-07d4d102c6c1480121cb55218b0152eaab71972ae74e1562eb3a81387a542667R96-R106) [[2]](diffhunk://#diff-07d4d102c6c1480121cb55218b0152eaab71972ae74e1562eb3a81387a542667L104-L134)
* Updated the `UnreadNotificationsByScope` type to use string keys for `fileId` and `noticeId`, ensuring consistency with how IDs are used throughout the application.

**Consistent use of string IDs for notification paths:**

* Refactored all usages of notification scopes and related functions (such as `clearNotificationScope` and `getUnreadsCount`) to consistently convert course, file, and notice IDs to strings when constructing notification paths, preventing mismatches and bugs. [[1]](diffhunk://#diff-b0fcf5f19d6b0d42c400a8578637fcd28fb0ed17640ad4e436ad1170f4af831aL191-R197) [[2]](diffhunk://#diff-57e937dbe0e6347553e0f014d7ce2a89f2e4b49ea46aa315f50999b43efe5144L115-R115) [[3]](diffhunk://#diff-6da71ac6a97e1e11a339956ace2845f58c7fa58416a40555a6980cdd7f67eb0aL37-R37) [[4]](diffhunk://#diff-7823368e712bba884319a6d279c5f7fb254e3bfaed8a9452dba15a8e23d4ce72L88-R92) [[5]](diffhunk://#diff-7823368e712bba884319a6d279c5f7fb254e3bfaed8a9452dba15a8e23d4ce72L121-R125) [[6]](diffhunk://#diff-6a4918b5f3c909aa5cc2f543f89cdc4e543f0271703aa2042ac1bf5a6f2e587eL46-R46) [[7]](diffhunk://#diff-6a4918b5f3c909aa5cc2f543f89cdc4e543f0271703aa2042ac1bf5a6f2e587eL80-R82) [[8]](diffhunk://#diff-dd873f178c51eeaeb3e15da0e19c5779b79ab1dc1f14519c073a72994efefa8cL40-R42) [[9]](diffhunk://#diff-ff8dd22283c8820e48e095ddeac543afcc0b29bd78f807d1efb26dd367f6b870L130-R144) [[10]](diffhunk://#diff-07d4d102c6c1480121cb55218b0152eaab71972ae74e1562eb3a81387a542667L163-R176)

**Minor improvements and code cleanup:**

* Improved handling of empty notification arrays in `clearNotificationScope` to prevent unnecessary operations, WHICH WAS LIKELY CAUSING INFINITE RECURSION IN CERTAIN PLACES.
* Cleaned up comments and removed outdated TODOs related to notification path typing. [[1]](diffhunk://#diff-07d4d102c6c1480121cb55218b0152eaab71972ae74e1562eb3a81387a542667L104-L134) [[2]](diffhunk://#diff-ff8dd22283c8820e48e095ddeac543afcc0b29bd78f807d1efb26dd367f6b870L130-R144)