### PR TITLE
fix(teaching): add missing space before links in notice content

### DIFF
--- a/src/utils/html.ts
+++ b/src/utils/html.ts
@@ -13,7 +13,8 @@ export const getHtmlTextContent = (text: string) => {
 };
 
 export const linkUrls = (html: string) => {
-  return Autolinker.link(html, {
+  const spaced = html.replace(/([^\s])((https?:\/\/|www\.)\S+)/g, '$1 $2');
+  return Autolinker.link(spaced, {
     truncate: 48,
   });
 };


### PR DESCRIPTION
## Description
Fix missing space before hyperlinks in the notice section.

When a notice contains a link, the space before the `<a>` tag was being 
stripped by Autolinker. Fixed by checking if the character before the 
link offset is a space, and prepending one if not.

## Related issue
Closes #775