### PR TITLE
Fix missing migration step for cache invalidation

### DIFF
--- a/src/core/migrations/MigrationService.ts
+++ b/src/core/migrations/MigrationService.ts
@@ -19,6 +19,10 @@ export class MigrationService {
       runBeforeVersion: '1.6.2',
       run: [migrateCourseFilesCacheToDocumentsDirectory],
     },
+    {
+      runBeforeVersion: '1.9.1',
+      run: [invalidateCache],
+    },
   ];
 
   static needsMigration(preferences: PreferencesContextProps) {
@@ -52,7 +56,6 @@ export class MigrationService {
       }
 
       console.debug('Updating lastInstalledVersion to', currentVersion);
-
       updatePreference('lastInstalledVersion', currentVersion);
     }
   }


### PR DESCRIPTION
Add a migration step to invalidate the cache for version 1.9.0, ensuring proper cache management during updates.